### PR TITLE
fix(ui): Adjust the border radius for the focused island.

### DIFF
--- a/interface/components/Island.tsx
+++ b/interface/components/Island.tsx
@@ -10,7 +10,7 @@ export default function Island(props: {
   return (
     <a
       class={
-        "sticky px-6 overflow-hidden py-3 max-w-xl mx-auto group rounded-full font-medium z-20 top-8 lg:bottom-8 w-full bg-white border border-neutral-200 shadow-xl shadow-neutral-500/5 mb-12 flex justify-between items-center dark:bg-neutral-950 dark:border-neutral-900 " +
+        "sticky px-6 overflow-hidden py-3 max-w-xl mx-auto group rounded-full focus:rounded-full font-medium z-20 top-8 lg:bottom-8 w-full bg-white border border-neutral-200 shadow-xl shadow-neutral-500/5 mb-12 flex justify-between items-center dark:bg-neutral-950 dark:border-neutral-900 " +
         props.class
       }
       href={props.link}


### PR DESCRIPTION
Note: The cause of the issue can be found at https://github.com/flornkm/florians-site/blob/c16831c9bf22db9118f0cd635d2bae3a4d74e540/design-system/global.css#L105-L109

| Before | After |
|:------:|:-----:|
| <img width="1382" height="240" alt="Click-2025-09-17-05 43 08@2x" src="https://github.com/user-attachments/assets/63cc52d9-8a4c-4772-a749-e4140367d0d4" />  | <img width="1382" height="240" alt="Click-2025-09-17-05 42 35@2x" src="https://github.com/user-attachments/assets/30fd25a3-5542-4e19-ae4e-3d68f406039d" />  |