### PR TITLE
Fix typos in Writing post (Dither)

### DIFF
--- a/src/content/writing/dither.mdx
+++ b/src/content/writing/dither.mdx
@@ -25,7 +25,7 @@ In the end, I started with what I thought was the simplest solution: custom SVG 
 
 But even that was not good. If I'd publish a package with custom SVG filters, I can't allow people to use it as a standalone tailwind plugin. Instead, people would have had to import a custom component containing the SVG filter, or I'd have to store the SVG filter as a URI object in the source CSS. This however didn't work for Safari browsers.
 
-A few months I didn't think about it and left the project still, as I was busy with other pojects.
+For a few months, I did not think about it and left the project as-is, as I was busy with other projects.
 
 Then, I needed the dither effect again, so I decided to try another rewrite approach.
 
@@ -48,4 +48,4 @@ So I tested it with some people from X, they gave me feedback, and I released at
 
 You can find the dither effect here: [Dither Plugin](https://dither.floriankiem.com/)
 
-Try it out for yoursefl! :)
+Try it out for yourself! :)


### PR DESCRIPTION
This PR fixes the typos spotted on the Writing page (Dither post) in branch redesign-2.

Changes
- pojects -> projects
- yoursefl -> yourself
- Polished one sentence for readability

No functional changes, copy-only update.
