### PR TITLE
Fix Colophon mobile CTA width (prevent full-width stretch)

### DIFF
--- a/src/pages/colophon/+Page.tsx
+++ b/src/pages/colophon/+Page.tsx
@@ -32,7 +32,10 @@ export default function Page() {
           <Link
             href="https://github.com/flornkm/florians-site"
             target="_blank"
-            className={cn(buttonVariants({ variant: "primary" }), "group flex items-center gap-2 px-2 py-0.5 text-inverted")}
+            className={cn(
+              buttonVariants({ variant: "primary" }),
+              "group w-auto shrink-0 self-center md:self-auto flex items-center gap-2 px-2 py-0.5 text-inverted",
+            )}
           >
             <IconGithub className="size-4" />
             Open Source Repo


### PR DESCRIPTION
Follow-up fix after merge: keep the Colophon floating GitHub CTA visible on mobile, but prevent it from stretching to full width.

Changes
- force CTA link width to auto (`w-auto`) and prevent stretching (`shrink-0`)
- keep alignment centered on mobile and unchanged on desktop

No behavior changes besides mobile width.
