### PR TITLE
Fix Colophon mobile floating CTA width to fit content

### DIFF
--- a/src/pages/colophon/+Page.tsx
+++ b/src/pages/colophon/+Page.tsx
@@ -27,7 +27,7 @@ export default function Page() {
       <div className="mb-16">
         <H1>Colophon</H1>
       </div>
-      <div className="sticky top-[calc(100dvh-6.75rem)] border border-black/10 z-20 mx-auto -mb-16 flex w-auto max-w-xs rounded-[10px] bg-surface-inverted shadow-xl md:top-[calc(100dvh-4.5rem)] md:max-w-[calc(100%-27rem)] md:justify-self-end md:flex-col">
+      <div className="sticky top-[calc(100dvh-6.75rem)] border border-black/10 z-20 mx-auto -mb-16 flex w-fit rounded-[10px] bg-surface-inverted shadow-xl md:top-[calc(100dvh-4.5rem)] md:max-w-[calc(100%-27rem)] md:justify-self-end md:flex-col">
         <div className="flex gap-0.5 p-0.5">
           <Link
             href="https://github.com/flornkm/florians-site"


### PR DESCRIPTION
Follow-up mobile fix: the floating CTA pill on Colophon should size to content, not appear stretched.

Change
- container width from `w-auto max-w-xs` to `w-fit`

Result
- CTA stays compact on mobile while preserving desktop behavior.
