### PR TITLE
fix: lock body scroll while iOS context menu is open

### DIFF
--- a/src/features/experiments/components/ios-context-menu-demo.tsx
+++ b/src/features/experiments/components/ios-context-menu-demo.tsx
@@ -198,6 +198,7 @@ export function IosContextMenu() {
   return (
     <div
       data-menu-open={open || undefined}
+      data-block-scroll={open || undefined}
       className="flex flex-col items-center w-full h-full select-none"
       onMouseMove={areaMove}
     >

--- a/src/features/experiments/components/ios-context-menu-demo.tsx
+++ b/src/features/experiments/components/ios-context-menu-demo.tsx
@@ -181,6 +181,15 @@ export function IosContextMenu() {
 
   const open = phase === "menu";
 
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
   const groups: { label: string; icon: string; destructive?: boolean }[][] = [];
   let current: { label: string; icon: string; destructive?: boolean }[] = [];
   for (const item of ITEMS) {

--- a/src/features/experiments/components/ios-context-menu-demo.tsx
+++ b/src/features/experiments/components/ios-context-menu-demo.tsx
@@ -181,15 +181,6 @@ export function IosContextMenu() {
 
   const open = phase === "menu";
 
-  useEffect(() => {
-    if (!open) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [open]);
-
   const groups: { label: string; icon: string; destructive?: boolean }[][] = [];
   let current: { label: string; icon: string; destructive?: boolean }[] = [];
   for (const item of ITEMS) {

--- a/src/routes/experiments.tsx
+++ b/src/routes/experiments.tsx
@@ -40,7 +40,7 @@ function ExperimentsPage() {
           <H2>{title}</H2>
           <div
             className={cn(
-              "rounded-xl bg-transparent border border-primary flex items-center justify-center overflow-hidden isolate has-[[data-menu-open]]:overflow-visible",
+              "relative rounded-xl bg-transparent border border-primary flex items-center justify-center overflow-hidden isolate has-[[data-menu-open]]:overflow-visible has-[[data-menu-open]]:z-[100]",
               aspect || "aspect-[4/3]",
             )}
           >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -185,8 +185,10 @@ body {
   font-weight: 450;
 }
 
+html:has([data-block-scroll]),
 body:has([data-block-scroll]) {
   overflow: hidden;
+  overscroll-behavior: none;
 }
 
 *:not([class*="outline-"]):not(input):not(textarea) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -185,6 +185,10 @@ body {
   font-weight: 450;
 }
 
+html:has([data-menu-open]) {
+  overflow: hidden;
+}
+
 *:not([class*="outline-"]):not(input):not(textarea) {
   @apply outline-0 outline-transparent;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -185,7 +185,7 @@ body {
   font-weight: 450;
 }
 
-html:has([data-menu-open]) {
+html:has([data-block-scroll]) {
   overflow: hidden;
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -185,7 +185,7 @@ body {
   font-weight: 450;
 }
 
-html:has([data-block-scroll]) {
+body:has([data-block-scroll]) {
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary
- Lock `document.body` scroll while the iOS context menu experiment is open, restoring the previous value on close.

## Test plan
- [ ] Open the experiments page, trigger the iOS context menu, and confirm the page no longer scrolls while the menu is visible.
- [ ] Dismiss the menu and confirm scrolling resumes normally.

https://claude.ai/code/session_01PPmjfwXZwTUH2Ni2KMBCTC